### PR TITLE
ObjectBox: unify Store/box usage, fix Mangayomi init; Android: add uninstallApp; wire Aniyomi setup

### DIFF
--- a/android/src/main/kotlin/com/aayush262/dartotsu_extension_bridge/aniyomi/AniyomiBridge.kt
+++ b/android/src/main/kotlin/com/aayush262/dartotsu_extension_bridge/aniyomi/AniyomiBridge.kt
@@ -51,6 +51,23 @@ class AniyomiBridge(private val context: Context) : MethodChannel.MethodCallHand
         }
     }
 
+    private fun uninstallApp(call: MethodCall, result: MethodChannel.Result) {
+        try {
+            val pkg = call.argument<String>("package") ?: run {
+                result.error("INVALID_ARGS", "Missing package name", null)
+                return
+            }
+            val uri = android.net.Uri.parse("package:$pkg")
+            val intent = android.content.Intent(android.content.Intent.ACTION_DELETE, uri)
+            intent.addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+            context.startActivity(intent)
+            result.success(true)
+        } catch (e: Exception) {
+            result.error("ERROR", "Failed to start uninstall intent: ${e.message}", null)
+        }
+    }
+
+
     private fun getInstalledAnimeExtensions(call: MethodCall, result: MethodChannel.Result) {
         val extensionManager = Injekt.get<AniyomiExtensionManager>()
         try {

--- a/lib/Aniyomi/AniyomiExtensions.dart
+++ b/lib/Aniyomi/AniyomiExtensions.dart
@@ -250,7 +250,7 @@ class AniyomiExtensions extends Extension {
     try {
       // Request system uninstall via platform channel (e.g., Android ACTION_DELETE intent).
       final bool started =
-          (await platform.invokeMethod('uninstallApp', packageName)) == true;
+          (await platform.invokeMethod('uninstallApp', { 'package': packageName })) == true;
       if (!started) {
         throw Exception('Failed to initiate uninstallation for: $packageName');
       }

--- a/lib/Common/objectbox.dart
+++ b/lib/Common/objectbox.dart
@@ -1,10 +1,12 @@
+// Deprecated: use the unified ObjectBox initialization in extension_bridge.dart
+// This file remains to avoid breaking imports; do not open a separate Store here.
 import 'package:dartotsu_extension_bridge/objectbox.g.dart';
 import 'package:dartotsu_extension_bridge/Mangayomi/Eval/dart/model/m_source.dart';
+import '../extension_bridge.dart';
 
-late final Store store;
 late final Box<MSource> objectboxMSourceBox;
 
 Future<void> initObjectBox() async {
-  store = await openStore();
-  objectboxMSourceBox = store.box<MSource>();
+  // Initialize boxes using the global store created by DartotsuExtensionBridge.init()
+  objectboxMSourceBox = objectboxStore.box<MSource>();
 }

--- a/lib/Mangayomi/MangayomiExtensionManager.dart
+++ b/lib/Mangayomi/MangayomiExtensionManager.dart
@@ -21,6 +21,9 @@ class MangayomiExtensionManager extends GetxController {
   @override
   void onInit() {
     super.onInit();
+    // Initialize the ObjectBox box once using the global store
+    objectboxMSourceBox = objectboxStore.box<MSource>();
+
     installedAnimeExtensions.bindStream(getExtensionsStream(ItemType.anime));
     installedMangaExtensions.bindStream(getExtensionsStream(ItemType.manga));
     installedNovelExtensions.bindStream(getExtensionsStream(ItemType.novel));
@@ -94,7 +97,7 @@ class MangayomiExtensionManager extends GetxController {
   Future<void> uninstallSource(Source source) async {
     try {
       var mSource = await getInstalled(source.itemType!, int.parse(source.id!));
-      objectboxMSourceBox.remove(mSource.id);
+      objectboxMSourceBox.remove(mSource.obxId);
     } catch (e) {
       debugPrint("Error uninstalling source: $e");
       return Future.error(e);

--- a/lib/Mangayomi/MangayomiExtensions.dart
+++ b/lib/Mangayomi/MangayomiExtensions.dart
@@ -24,8 +24,8 @@ class MangayomiExtensions extends Extension {
 
   final _manager = Get.put(MangayomiExtensionManager());
 
-  late final Store _store = Get.find<Store>();
-  late final Box<BridgeSettings> _settingsBox = _store.box<BridgeSettings>();
+  // Use the global ObjectBox store initialized in extension_bridge.dart
+  late final Box<BridgeSettings> _settingsBox = objectboxStore.box<BridgeSettings>();
 
   BridgeSettings _getSettings() {
     final settings = _settingsBox.get(26);

--- a/lib/Mangayomi/extension_preferences_providers.dart
+++ b/lib/Mangayomi/extension_preferences_providers.dart
@@ -2,14 +2,13 @@ import 'Eval/dart/model/source_preference.dart';
 import 'Models/Source.dart';
 import '../objectbox.g.dart';
 
-late final Store store;
 late final Box<SourcePreference> sourcePreferenceBox;
 late final Box<SourcePreferenceStringValue> sourcePreferenceStringValueBox;
 
 Future<void> initObjectBox() async {
-  store = await openStore();
-  sourcePreferenceBox = store.box<SourcePreference>();
-  sourcePreferenceStringValueBox = store.box<SourcePreferenceStringValue>();
+  // Use the globally initialized store from extension_bridge.dart
+  sourcePreferenceBox = objectboxStore.box<SourcePreference>();
+  sourcePreferenceStringValueBox = objectboxStore.box<SourcePreferenceStringValue>();
 }
 
 void setPreferenceSetting(SourcePreference sourcePreference, MSource source) {
@@ -21,9 +20,9 @@ void setPreferenceSetting(SourcePreference sourcePreference, MSource source) {
       .build()
       .findFirst();
 
-  store.runInTransaction(TxMode.write, () {
+  objectboxStore.runInTransaction(TxMode.write, () {
     if (sourcePref != null) {
-      sourcePreferenceBox.put(sourcePreference);
+      sourcePreferenceBox.put(sourcePreference..id = sourcePref.id);
     } else {
       sourcePreferenceBox.put(sourcePreference..sourceId = source.id);
     }
@@ -83,7 +82,7 @@ void setSourcePreferenceStringValue(int sourceId, String key, String value) {
       .build()
       .findFirst();
 
-  store.runInTransaction(TxMode.write, () {
+  objectboxStore.runInTransaction(TxMode.write, () {
     if (sourcePref != null) {
       sourcePreferenceStringValueBox.put(sourcePref..value = value);
     } else {

--- a/lib/extension_bridge.dart
+++ b/lib/extension_bridge.dart
@@ -31,7 +31,12 @@ class DartotsuExtensionBridge {
       bridgeSettingsBox.put(BridgeSettings()..id = 26);
     }
 
+    // Make Store available via Get for any consumers that rely on DI
+    Get.put<Store>(objectboxStore);
+
     if (Platform.isAndroid) {
+      // Ensure AniyomiExtensions can access the global store/boxes if needed
+      AniyomiExtensions.setupObjectBox(objectboxStore);
       Get.put(AniyomiExtensions(), tag: 'AniyomiExtensions');
     }
     Get.put(MangayomiExtensions(), tag: 'MangayomiExtensions');


### PR DESCRIPTION
Summary
- Unify ObjectBox usage and initialization
- Fix Mangayomi box initialization and deletion ID
- Implement Android uninstallApp method channel
- Wire Aniyomi setup to shared ObjectBox Store

Changes
- Inject shared Store via Get in extension_bridge.dart and initialize BridgeSettings
- Initialize Mangayomi's objectboxMSourceBox once from the global Store
- Refactor extension_preferences_providers to use the shared Store instead of opening another Store
- Fix uninstallSource() to delete by obxId instead of logical id
- Android: implement MethodChannel handler uninstallApp (ACTION_DELETE) and call from Dart with {package}
- Call AniyomiExtensions.setupObjectBox(store) during init so it can access BridgeSettings via Box<BridgeSettings>
- Mark Common/objectbox.dart as deprecated shim using the global store rather than opening a new Store

Motivation
- Prevent multiple Stores/DB locks and resolve DI runtime errors (Get.find<Store> failure)
- Ensure ObjectBox boxes are initialized before use
- Add platform parity for uninstallation requested by the Dart layer

Testing considerations
- Run `dart run build_runner build` if models change
- On Android: verify MethodChannel uninstallApp starts the uninstall intent and Dart receives `true`
- Validate extension list streams and preference saving now work with the unified Store

Notes
- Aniyomi supportsNovel remains false; we no longer rely on an unimplemented getInstalledNovelExtensions on platform side

Co-authored-by: openhands <openhands@all-hands.dev>

@SyedArbaazHussain can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a26273e16ce3465486631105ed9a3a93)